### PR TITLE
 add inspect hook after a successor has been created 

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -114,6 +114,7 @@ class SimSuccessors(object):
         state.scratch.exit_ins_addr = exit_ins_addr
 
         self._preprocess_successor(state, add_guard=add_guard)
+        state._inspect('successor', BP_AFTER)
 
         if state.history.jumpkind == 'Ijk_SigFPE_IntDiv' and o.PRODUCE_ZERODIV_SUCCESSORS not in state.options:
             return

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -18,6 +18,7 @@ event_types = {
     'constraints',
     'exit',
     'fork',
+    'successor',
     'symbolic_variable',
     'call',
     'return',


### PR DESCRIPTION
We need this to concretize instruction pointer.